### PR TITLE
update vulnerable dependencies reported by snyk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
             docker.image(env.GRADLE_DOCKER_IMAGE).inside("-e GRADLE_USER_HOME=${WORKSPACE}/.gradle -e SONAR_USER_HOME=${WORKSPACE}/.sonar") {
               if (env.BRANCH_NAME.startsWith("PR-")) {
                 withCredentials([[$class: 'StringBinding', credentialsId: 'auth0extensions-token', variable: 'GITHUB_ACCESS_TOKEN']]) {
-                  sh "gradle sonarqube -x check -Partifactory_user=${ARTIFACTORY_USER} -Partifactory_password=${ARTIFACTORY_PASS} -Dsonar.host.url=${env.SONAR_HOST_URL} -Dsonar.login=${env.SONAR_AUTH_TOKEN} -Dsonar.github.pullRequest=${env.CHANGE_ID} -Dsonar.github.oauth=${GITHUB_ACCESS_TOKEN} -Dsonar.github.repository=auth0/${env.JOB_NAME} -Dsonar.analysis.mode=preview"
+                  sh "gradle sonarqube -x check -Partifactory_user=${ARTIFACTORY_USER} -Partifactory_password=${ARTIFACTORY_PASS} -Dsonar.host.url=${env.SONAR_HOST_URL} -Dsonar.login=${env.SONAR_AUTH_TOKEN} -Dsonar.github.pullRequest=${env.CHANGE_ID} -Dsonar.github.oauth=${GITHUB_ACCESS_TOKEN} -Dsonar.github.repository=auth0/${env.JOB_NAME}"
                 }
               } else if (env.BRANCH_NAME == 'master') {
                 sh "gradle sonarqube -x check -Partifactory_user=${ARTIFACTORY_USER} -Partifactory_password=${ARTIFACTORY_PASS} -Dsonar.host.url=${env.SONAR_HOST_URL} -Dsonar.login=${env.SONAR_AUTH_TOKEN}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.franzbecker.gradle-lombok' version '1.14'
     id 'com.jfrog.artifactory' version '4.8.1'
-    id 'org.sonarqube' version '2.6.2'
+    id 'org.sonarqube' version '2.8'
     id 'com.auth0.versions' version '1.2.0'
     id 'java-library'
     id 'maven-publish'
@@ -38,7 +38,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.21'
 
     implementation 'com.google.guava:guava:27.0.1-jre'
-    implementation 'org.postgresql:postgresql:42.2.6'
+    implementation 'org.postgresql:postgresql:42.2.14'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.10'
     implementation 'net.jodah:failsafe:1.0.4'
 
@@ -47,10 +47,10 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
 
-    compile 'io.netty:netty-buffer:4.1.22.Final'
-    compile 'io.netty:netty-codec:4.1.22.Final'
-    compile 'io.netty:netty-handler:4.1.22.Final'
-    compile 'io.netty:netty-transport:4.1.22.Final'
+    compile 'io.netty:netty-buffer:4.1.46.Final'
+    compile 'io.netty:netty-codec:4.1.46.Final'
+    compile 'io.netty:netty-handler:4.1.46.Final'
+    compile 'io.netty:netty-transport:4.1.46.Final'
 
 }
 

--- a/src/main/java/io/zrz/jpgsql/client/CommandStatus.java
+++ b/src/main/java/io/zrz/jpgsql/client/CommandStatus.java
@@ -16,7 +16,7 @@ public class CommandStatus implements QueryResult {
 
   private String status;
 
-  private int updateCount;
+  private long updateCount;
 
   private long insertOID;
 

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgObservableResultHandler.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgObservableResultHandler.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import org.postgresql.core.Field;
 import org.postgresql.core.ResultCursor;
 import org.postgresql.core.ResultHandlerBase;
+import org.postgresql.core.Tuple;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLWarning;
 
@@ -48,7 +49,7 @@ public class PgObservableResultHandler extends ResultHandlerBase {
   }
 
   @Override
-  public void handleResultRows(final org.postgresql.core.Query fromQuery, final Field[] fields, final List<byte[][]> tuples, final ResultCursor cursor) {
+  public void handleResultRows(final org.postgresql.core.Query fromQuery, final Field[] fields, final List<Tuple> tuples, final ResultCursor cursor) {
 
     if (cursor != null) {
       this.cursor = cursor;
@@ -94,7 +95,7 @@ public class PgObservableResultHandler extends ResultHandlerBase {
   }
 
   @Override
-  public void handleCommandStatus(final String status, final int updateCount, final long insertOID) {
+  public void handleCommandStatus(final String status, final long updateCount, final long insertOID) {
     final CommandStatus msg = new CommandStatus(this.statementId, status, updateCount, insertOID);
     log.trace("[{}] {}", this.statementId, msg);
     this.statementId++;

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.postgresql.core.Field;
+import org.postgresql.core.Tuple;
 import org.postgresql.util.PGbytea;
 
 import com.google.common.base.Splitter;
@@ -23,11 +24,11 @@ final class PgResultRows implements RowBuffer {
 
   private final Query query;
   private final PgResultMeta fields;
-  private final List<byte[][]> tuples;
+  private final List<Tuple> tuples;
   private final boolean done;
   private final int statementId;
 
-  PgResultRows(final Query query, final int statementId, final PgResultMeta fields, final List<byte[][]> tuples, final boolean done) {
+  PgResultRows(final Query query, final int statementId, final PgResultMeta fields, final List<Tuple> tuples, final boolean done) {
     this.statementId = statementId;
     this.query = query;
     this.fields = fields;
@@ -72,7 +73,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public int intval(final int row, final int col) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       throw new NullPointerException();
     }
@@ -89,7 +90,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public int intval(final int row, final int col, final int defaultValue) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       return defaultValue;
     }
@@ -98,7 +99,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public byte[] bytes(final int row, final int col) {
-    return this.tuples.get(row)[col];
+    return this.tuples.get(row).get(col);
   }
 
   @Override
@@ -108,7 +109,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public String strval(final int row, final int col) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       return null;
     }
@@ -122,7 +123,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public long longval(final int row, final int col) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       throw new NullPointerException();
     }
@@ -131,7 +132,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public long longval(final int row, final int col, final long defaultValue) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       return defaultValue;
     }
@@ -140,7 +141,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public BigDecimal decimal(final int row, final int col) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       return null;
     }
@@ -149,7 +150,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public Instant instant(final int row, final int col) {
-    final byte[] val = this.tuples.get(row)[col];
+    final byte[] val = this.tuples.get(row).get(col);
     if (val == null) {
       return null;
     }
@@ -158,7 +159,7 @@ final class PgResultRows implements RowBuffer {
 
   @Override
   public boolean boolval(int row, int field) {
-    final byte[] val = this.tuples.get(row)[field];
+    final byte[] val = this.tuples.get(row).get(field);
     if (val == null) {
       throw new NullPointerException();
     }
@@ -178,7 +179,7 @@ final class PgResultRows implements RowBuffer {
 
     final int oid = field.oid();
 
-    byte[] raw = tuples.get(row)[i];
+    byte[] raw = tuples.get(row).get(i);
 
     if (field.format() == Field.TEXT_FORMAT) {
       return PGbytea.toBytes(raw);


### PR DESCRIPTION
This update fixes:

Issues with no direct upgrade or patch:
  ✗ Uncontrolled Memory Allocation [High Severity][https://snyk.io/vuln/SNYK-JAVA-IONETTY-564897] in io.netty:netty-codec@4.1.22.Final
    introduced by io.zrz:jpgsql-client@0.3.0 > io.netty:netty-codec@4.1.22.Final and 3 other path(s)
  This issue was fixed in versions: 4.1.46.Final
  ✗ XML External Entity (XXE) Injection [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-571481] in org.postgresql:postgresql@42.2.6
    introduced by io.zrz:jpgsql-client@0.3.0 > org.postgresql:postgresql@42.2.6 and 1 other path(s)
  This issue was fixed in versions: 42.2.13
