### PR TITLE
[IUM-2173] chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.
-*    @auth0/iam-user-management-engineer
+*    @auth0/iam-user-services-engineer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 - Follow existing code style and conventions
 - Separate unrelated changes into multiple pull requests
 - For bigger changes, make sure you start a discussion first by creating an issue and explaining the intended change
-- This repository requires 2 reviews from the IAM User Management Engineering Team
+- This repository requires 2 reviews from the IAM User Services Engineering Team
 
 ## Development dependencies
 


### PR DESCRIPTION
### Description

Update CODEOWNERS file to reflect repository ownership after team split. 

### References

JIRA: https://auth0team.atlassian.net/browse/IUM-2173

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
