### PR TITLE
fix: allow disabling binary transfer for certain fields

### DIFF
--- a/src/main/java/io/zrz/jpgsql/client/PostgresConnectionProperties.java
+++ b/src/main/java/io/zrz/jpgsql/client/PostgresConnectionProperties.java
@@ -133,4 +133,7 @@ public class PostgresConnectionProperties {
   @Default
   private boolean debug = false;
 
+  @Default
+  private String binaryTransferDisable = null;
+
 }

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
@@ -232,8 +232,7 @@ final class PgResultRows implements RowBuffer {
 
     }
 
-    throw new IllegalArgumentException();
-
+    throw new IllegalArgumentException(String.format("unhandled format for text array field: %s", field.format()));
   }
 
 }

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
@@ -210,7 +210,7 @@ final class PgResultRows implements RowBuffer {
         return Splitter.on(' ').splitToList(strval(row, column)).stream().mapToInt(x -> Integer.parseInt(x)).toArray();
     }
 
-    throw new IllegalArgumentException();
+    throw new IllegalArgumentException(String.format("unhandled format for int array field: %d", field.format()));
 
   }
 
@@ -232,7 +232,7 @@ final class PgResultRows implements RowBuffer {
 
     }
 
-    throw new IllegalArgumentException(String.format("unhandled format for text array field: %s", field.format()));
+    throw new IllegalArgumentException(String.format("unhandled format for text array field: %d", field.format()));
   }
 
 }

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgResultRows.java
@@ -210,7 +210,7 @@ final class PgResultRows implements RowBuffer {
         return Splitter.on(' ').splitToList(strval(row, column)).stream().mapToInt(x -> Integer.parseInt(x)).toArray();
     }
 
-    throw new IllegalArgumentException(String.format("unhandled format for int array field: %d", field.format()));
+    throw new IllegalArgumentException(String.format("unhandled format for int array field: %s", field.toString()));
 
   }
 
@@ -232,7 +232,7 @@ final class PgResultRows implements RowBuffer {
 
     }
 
-    throw new IllegalArgumentException(String.format("unhandled format for text array field: %d", field.format()));
+    throw new IllegalArgumentException(String.format("unhandled format for text array field: %s", field.toString()));
   }
 
 }

--- a/src/main/java/io/zrz/jpgsql/client/opj/PgThreadPooledClient.java
+++ b/src/main/java/io/zrz/jpgsql/client/opj/PgThreadPooledClient.java
@@ -128,6 +128,11 @@ public class PgThreadPooledClient extends AbstractPostgresClient implements Post
 
     this.ds.setBinaryTransfer(true);
 
+    // Explicitly disable binary transfer for certain field types
+    if (config.getBinaryTransferDisable() != null) {
+      this.ds.setBinaryTransferDisable(config.getBinaryTransferDisable());
+    }
+
     // reasonably large default fetch size
 
     if (config.getDefaultRowFetchSize() > 0)


### PR DESCRIPTION
### Description

Expose configuration property to manually disable binary transfer for certain field types. 

This is needed because we currently don't support binary decoding for `text_array` fields. 

### References

https://auth0.slack.com/archives/C03Q34ESR8B/p1676481245544369

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
